### PR TITLE
Feat/#6 - 회원가입 API 구현

### DIFF
--- a/src/main/java/com/kwakmunsu/vote/controller/AuthController.java
+++ b/src/main/java/com/kwakmunsu/vote/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.kwakmunsu.vote.controller;
+
+
+import com.kwakmunsu.vote.dto.AuthDto;
+import com.kwakmunsu.vote.response.ResponseCode;
+import com.kwakmunsu.vote.response.ResponseData;
+import com.kwakmunsu.vote.service.AuthService;
+import com.kwakmunsu.vote.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    @PostMapping("/signup")
+    public ResponseEntity<ResponseData> signup(@RequestBody AuthDto.SignUpRequest signUpRequestDto) {
+        authService.signup(signUpRequestDto);
+        return ResponseData.toResponseEntity(ResponseCode.CREATED_USER);
+
+
+    }
+
+}

--- a/src/main/java/com/kwakmunsu/vote/controller/UserController.java
+++ b/src/main/java/com/kwakmunsu/vote/controller/UserController.java
@@ -3,6 +3,7 @@ package com.kwakmunsu.vote.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,5 +12,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
+
+
+
+
 
 }

--- a/src/main/java/com/kwakmunsu/vote/domain/User.java
+++ b/src/main/java/com/kwakmunsu/vote/domain/User.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +29,12 @@ public class User {
     private String nickname;
 
     private String password;
+
+
+    @Builder(builderClassName = "UserSaveBuilder", builderMethodName = "UserSaveBuilder")
+    public User(String username, String password, String nickname) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/kwakmunsu/vote/dto/AuthDto.java
+++ b/src/main/java/com/kwakmunsu/vote/dto/AuthDto.java
@@ -1,0 +1,48 @@
+package com.kwakmunsu.vote.dto;
+
+
+import com.kwakmunsu.vote.domain.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthDto {
+
+    // ====== requestDto ======
+
+    @Getter
+    @NoArgsConstructor
+    public static class SignUpRequest {
+
+        private String username;
+        private String password;
+        private String nickname;
+
+        public User toEntity() {
+            return User.UserSaveBuilder()
+                    .username(this.username)
+                    .password(this.password)
+                    .nickname(this.nickname)
+                    .build();
+        }
+    }
+
+
+    @Getter
+    @NoArgsConstructor
+    public static class LoginRequest {
+
+        private String username;
+        private String password;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateRequest {
+
+        private String username;
+        private String password;
+        private String newPassword;
+    }
+
+
+}

--- a/src/main/java/com/kwakmunsu/vote/dto/UserDto.java
+++ b/src/main/java/com/kwakmunsu/vote/dto/UserDto.java
@@ -1,0 +1,5 @@
+package com.kwakmunsu.vote.dto;
+
+public class UserDto {
+
+}

--- a/src/main/java/com/kwakmunsu/vote/repository/UserRepository.java
+++ b/src/main/java/com/kwakmunsu/vote/repository/UserRepository.java
@@ -1,8 +1,13 @@
 package com.kwakmunsu.vote.repository;
 
 import com.kwakmunsu.vote.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface UserRepository extends JpaRepository<Long, User> {
+@Repository
+public interface UserRepository extends JpaRepository<User,Long> {
+    Optional<User> findByUsername(String username);
+    Optional<User> findByNickname(String nickname);
 
 }

--- a/src/main/java/com/kwakmunsu/vote/repository/UserVotesRepository.java
+++ b/src/main/java/com/kwakmunsu/vote/repository/UserVotesRepository.java
@@ -3,6 +3,6 @@ package com.kwakmunsu.vote.repository;
 import com.kwakmunsu.vote.domain.UserVotes;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserVotesRepository extends JpaRepository<Long, UserVotes> {
+public interface UserVotesRepository extends JpaRepository<UserVotes,Long> {
 
 }

--- a/src/main/java/com/kwakmunsu/vote/repository/VoteRepository.java
+++ b/src/main/java/com/kwakmunsu/vote/repository/VoteRepository.java
@@ -3,6 +3,6 @@ package com.kwakmunsu.vote.repository;
 import com.kwakmunsu.vote.domain.Vote;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VoteRepository extends JpaRepository<Long, Vote> {
+public interface VoteRepository extends JpaRepository<Vote,Long> {
 
 }

--- a/src/main/java/com/kwakmunsu/vote/response/ResponseCode.java
+++ b/src/main/java/com/kwakmunsu/vote/response/ResponseCode.java
@@ -1,0 +1,58 @@
+package com.kwakmunsu.vote.response;
+
+import com.kwakmunsu.vote.response.exception.MessageItem;
+import com.kwakmunsu.vote.response.exception.StatusItem;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ResponseCode  {
+    // ===================== //
+
+    // User 관련 성공 응답
+    CREATED_USER(StatusItem.CREATED, MessageItem.CREATED_USER),
+    READ_USER(StatusItem.OK, MessageItem.READ_USER),
+    UPDATE_USER(StatusItem.NO_CONTENT, MessageItem.UPDATE_USER),
+    DELETE_USER(StatusItem.NO_CONTENT, MessageItem.DELETE_USER),
+
+    // User 관련 실패 응답
+    NOT_FOUND_USER(StatusItem.NOT_FOUND, MessageItem.NOT_FOUND_USER),
+    BAD_REQUEST_USER(StatusItem.BAD_REQUEST, MessageItem.BAD_REQUEST_USER),
+    DUPLICATE_EMAIL(StatusItem.BAD_REQUEST, MessageItem.DUPLICATE_USER),
+
+    // ===================== //
+
+    // vote 관련 성공 응답
+    CREATED_VOTE(StatusItem.CREATED, MessageItem.CREATED_VOTE),
+    READ_VOTE(StatusItem.OK, MessageItem.READ_VOTE),
+    READ_VOTES(StatusItem.OK, MessageItem.READ_VOTES),
+    UPDATE_VOTE(StatusItem.NO_CONTENT, MessageItem.UPDATE_VOTE),
+    DELETE_VOTE(StatusItem.NO_CONTENT, MessageItem.DELETE_VOTE),
+
+    // vote 관련 실패 응답
+    NOT_FOUND_VOTE(StatusItem.NOT_FOUND, MessageItem.NOT_FOUND_VOTE),
+    BAD_REQUEST_VOTE(StatusItem.BAD_REQUEST, MessageItem.BAD_REQUEST_VOTE),
+
+
+
+
+    // ===================== //
+
+    // 기타 성공 응답
+    READ_IS_LOGIN(StatusItem.OK, MessageItem.READ_IS_LOGIN),
+    LOGIN_SUCCESS(StatusItem.OK, MessageItem.LOGIN_SUCCESS),
+    UPDATE_PASSWORD(StatusItem.NO_CONTENT, MessageItem.UPDATE_PASSWORD),
+    PREVENT_GET_ERROR(StatusItem.NO_CONTENT, MessageItem.PREVENT_GET_ERROR),
+
+    // 기타 실패 응답
+    INTERNAL_SERVER_ERROR(StatusItem.INTERNAL_SERVER_ERROR, MessageItem.INTERNAL_SERVER_ERROR),
+    UNAUTHORIZED_ERROR(StatusItem.UNAUTHORIZED, MessageItem.UNAUTHORIZED),
+    FORBIDDEN_ERROR(StatusItem.FORBIDDEN, MessageItem.FORBIDDEN),
+    ;
+
+
+    private  int httpStatus;
+    private String message;
+
+}

--- a/src/main/java/com/kwakmunsu/vote/response/ResponseData.java
+++ b/src/main/java/com/kwakmunsu/vote/response/ResponseData.java
@@ -1,0 +1,59 @@
+package com.kwakmunsu.vote.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@Builder
+@ToString
+public class ResponseData<T> {
+
+    private final int status;
+    private final String message;
+    private final ResponseCode code;
+    private T data;
+
+    // response data가 없을때
+    public static ResponseEntity<ResponseData> toResponseEntity(ResponseCode responseCode) {
+        return ResponseEntity
+                .status(responseCode.getHttpStatus())
+                .body(ResponseData.builder()
+                        .status(responseCode.getHttpStatus())
+                        .message(responseCode.getMessage())
+                        .code(responseCode)
+                        .build()
+                );
+    }
+
+    // response data가 있을때
+    public static <T> ResponseEntity<ResponseData<T>> toResponseEntity(ResponseCode responseCode, T data) {
+        return ResponseEntity
+                .status(responseCode.getHttpStatus())
+                .body(ResponseData.<T>builder()
+                        .status(responseCode.getHttpStatus())
+                        .message(responseCode.getMessage())
+                        .code(responseCode)
+                        .data(data)
+                        .build()
+                );
+    }
+
+    // response data와 header가 있을때
+    public static <T> ResponseEntity<ResponseData<T>> toResponseEntity(ResponseCode responseCode, MultiValueMap<String, String> header, T data) {
+        return ResponseEntity
+                .status(responseCode.getHttpStatus())
+                .header(String.valueOf(header))
+                .body(ResponseData.<T>builder()
+                        .status(responseCode.getHttpStatus())
+                        .message(responseCode.getMessage())
+                        .code(responseCode)
+                        .data(data)
+                        .build()
+                );
+    }
+
+}

--- a/src/main/java/com/kwakmunsu/vote/response/exception/MessageItem.java
+++ b/src/main/java/com/kwakmunsu/vote/response/exception/MessageItem.java
@@ -1,0 +1,38 @@
+package com.kwakmunsu.vote.response.exception;
+
+public class MessageItem {
+
+        // < User >
+        public static final String CREATED_USER = "SUCCESS - 회원 가입 성공";
+        public static final String READ_USER = "SUCCESS - 회원 정보 조회 성공";
+        public static final String UPDATE_USER = "SUCCESS - 회원 정보 수정 성공";
+        public static final String DELETE_USER = "SUCCESS - 회원 탈퇴 성공";
+        public static final String NOT_FOUND_USER = "ERROR - 회원을 찾을 수 없습니다.";
+        public static final String BAD_REQUEST_USER = "ERROR - 잘못된 회원 요청 에러";
+        public static final String DUPLICATE_USER = "ERROR - 회원가입 ID,닉네임 중복 에러";
+
+        // < Memo >
+        public static final String CREATED_VOTE = "SUCCESS - 투표 생성 성공";
+        public static final String READ_VOTE = "SUCCESS - 투표 정보 조회 성공";
+        public static final String READ_VOTES = "SUCCESS - 회원의 투표 목록 조회 성공";
+        public static final String UPDATE_VOTE = "SUCCESS - 투표 수정 성공";
+        public static final String DELETE_VOTE = "SUCCESS - 투표 삭제 성공";
+        public static final String NOT_FOUND_VOTE = "ERROR - 투표를 찾을 수 없습니다.";
+        public static final String BAD_REQUEST_VOTE = "ERROR - 잘못된 투표 요청 에러";
+
+
+
+        // < Auth >
+        public static final String LOGIN_SUCCESS = "SUCCESS - 로그인 성공";
+        public static final String UPDATE_PASSWORD = "SUCCESS - 비밀번호 수정 성공";
+        public static final String READ_IS_LOGIN = "SUCCESS - 현재 로그인 여부 조회 성공";
+        public static final String UNAUTHORIZED = "ERROR - Unauthorized 에러";
+        public static final String FORBIDDEN = "ERROR - Forbidden 에러"; // 권한 없을 때
+        public static final String PREVENT_GET_ERROR = "Status 204 - 리소스 및 리다이렉트 GET호출 에러 방지";
+
+        // < Token >
+
+        // < Etc >
+        public static final String INTERNAL_SERVER_ERROR = "ERROR - 서버 내부 에러";
+    }
+

--- a/src/main/java/com/kwakmunsu/vote/response/exception/StatusItem.java
+++ b/src/main/java/com/kwakmunsu/vote/response/exception/StatusItem.java
@@ -1,0 +1,14 @@
+package com.kwakmunsu.vote.response.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class StatusItem {
+    public static final int OK = HttpStatus.OK.value();
+    public static final int CREATED = HttpStatus.CREATED.value();
+    public static final int NO_CONTENT = HttpStatus.NO_CONTENT.value();
+    public static final int BAD_REQUEST =  HttpStatus.BAD_REQUEST.value();
+    public static final int UNAUTHORIZED = HttpStatus.UNAUTHORIZED.value();
+    public static final int FORBIDDEN = HttpStatus.FORBIDDEN.value();
+    public static final int NOT_FOUND = HttpStatus.NOT_FOUND.value();
+    public static final int INTERNAL_SERVER_ERROR = HttpStatus.INTERNAL_SERVER_ERROR.value();
+}

--- a/src/main/java/com/kwakmunsu/vote/service/AuthService.java
+++ b/src/main/java/com/kwakmunsu/vote/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.kwakmunsu.vote.service;
+
+import com.kwakmunsu.vote.dto.AuthDto;
+
+public interface AuthService {
+    void signup(AuthDto.SignUpRequest signUpRequestDto );
+    void updatePassword(AuthDto.UpdateRequest updateRequestDto);
+}

--- a/src/main/java/com/kwakmunsu/vote/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/kwakmunsu/vote/service/impl/AuthServiceImpl.java
@@ -1,0 +1,38 @@
+package com.kwakmunsu.vote.service.impl;
+
+import com.kwakmunsu.vote.domain.User;
+import com.kwakmunsu.vote.dto.AuthDto.SignUpRequest;
+import com.kwakmunsu.vote.dto.AuthDto.UpdateRequest;
+import com.kwakmunsu.vote.repository.UserRepository;
+import com.kwakmunsu.vote.service.AuthService;
+import com.sun.jdi.request.DuplicateRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private final UserRepository userRepository;
+    @Transactional
+    @Override
+    public void signup(SignUpRequest signUpRequestDto) {
+        // 중복 체크
+        String username = signUpRequestDto.getUsername();
+        String nickname = signUpRequestDto.getNickname();
+        userRepository.findByUsername(username)
+                        .ifPresent(user -> {throw new DuplicateRequestException("해당 id가 존재합니다."); });
+        userRepository.findByNickname(nickname)
+                .ifPresent(user -> {throw new DuplicateRequestException("해당 닉네임이 존재합니다."); });
+
+        User user = signUpRequestDto.toEntity();
+
+        userRepository.save(user);
+    }
+
+    @Override
+    public void updatePassword(UpdateRequest updateRequestDto) {
+
+    }
+}


### PR DESCRIPTION
# <i>PULL REQUEST</i>


## #️⃣연관된 이슈 

Feat/#6

## 📝작업 내용
- 회원 가입 API 구현했습니다. 
- id와 닉네임은 중복 체크 했습니다.
- 예외 처리는 아직 못했습니다. 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지, 코드 첨부 가능)

### 스크린샷
<img width="482" alt="스크린샷 2024-12-07 오후 11 12 01" src="https://github.com/user-attachments/assets/bb6c0a23-e507-4821-bab0-02302ec24c88">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
