### PR TITLE
Feat/#17 - 중복체크 API 구현

### DIFF
--- a/src/main/java/com/kwakmunsu/vote/config/SecurityConfig.java
+++ b/src/main/java/com/kwakmunsu/vote/config/SecurityConfig.java
@@ -21,7 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity // 시큐리티에서 관리하게 됨
 public class SecurityConfig {
     private final String[] adminUrl = {"/admin/**"};
-    private final String[] permitAllUrl = {"/","/error","/login","/logout","/signup","/reissue","/swagger/**","/swagger-ui/**","/v3/api-docs/**"};
+    private final String[] permitAllUrl = {"/","/error","/auth/**","/swagger/**","/swagger-ui/**","/v3/api-docs/**"};
     private final String[] hasRoleUrl = {"/vote/**"};
 
     private final JWTFilter jwtFilter;

--- a/src/main/java/com/kwakmunsu/vote/controller/AuthController.java
+++ b/src/main/java/com/kwakmunsu/vote/controller/AuthController.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,12 +30,28 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
-    @PostMapping("/signup")
+    @PostMapping("/signup") // 중복 API는 따로 만듦. 해당 경로를 클라이언트에서 요청 시 유효하기 때문에 바로 DB 저장
     public ResponseEntity<ResponseData> signup(@RequestBody AuthDto.SignUpRequest signUpRequestDto) {
         authService.signup(signUpRequestDto);
         return ResponseData.toResponseEntity(ResponseCode.CREATED_USER);
-
-
+    }
+    @GetMapping("/username/{username}")
+    public ResponseEntity<ResponseData> checkUsername(@PathVariable String username) {
+        log.info("check username...");
+        if (authService.checkUsername(username)) { // 중복인 경우
+            return ResponseData.toResponseEntity(ResponseCode.DUPLICATE_ID);
+        } else {
+            return ResponseData.toResponseEntity(ResponseCode.USERNAME_SUCCESS);
+        }
+    }
+    @GetMapping("/nickname/{nickname}")
+    public ResponseEntity<ResponseData> checkNickname(@PathVariable String nickname) {
+        log.info("check nickname...");
+        if (authService.checkUsername(nickname)) { // 중복인 경우
+            return ResponseData.toResponseEntity(ResponseCode.DUPLICATE_NICKNAME);
+        } else {
+            return ResponseData.toResponseEntity(ResponseCode.NICKNAME_SUCCESS);
+        }
     }
 
     @PostMapping("/login")
@@ -62,5 +80,7 @@ public class AuthController {
          authService.logout(request,response);
         return ResponseData.toResponseEntity(ResponseCode.LOGOUT_SUCCESS);
     }
+
+
 
 }

--- a/src/main/java/com/kwakmunsu/vote/controller/AuthController.java
+++ b/src/main/java/com/kwakmunsu/vote/controller/AuthController.java
@@ -17,10 +17,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Log4j2
 @Tag(name = "Auth")
+@RequestMapping("/auth")
 @RestController
 @RequiredArgsConstructor
 public class AuthController {

--- a/src/main/java/com/kwakmunsu/vote/jwt/JWTFilter.java
+++ b/src/main/java/com/kwakmunsu/vote/jwt/JWTFilter.java
@@ -60,7 +60,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String[] excludePath = {"/login","/logout","/signup","/reissue","/swagger/**","/swagger-ui/**","/v3/api-docs/**"};//"/v3/api-docs/**" 추가해줘야 swagger 작동
+        String[] excludePath = {"/auth/**","/swagger/**","/swagger-ui/**","/v3/api-docs/**"};//"/v3/api-docs/**" 추가해줘야 swagger 작동
         String path = request.getRequestURI();
         return Arrays.stream(excludePath).anyMatch(path::startsWith);
     }

--- a/src/main/java/com/kwakmunsu/vote/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/kwakmunsu/vote/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -44,6 +44,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     }
 
     private void sendError(HttpServletResponse response, String msg, int code) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");
         JwtExceptionResponse responseJson = new JwtExceptionResponse(

--- a/src/main/java/com/kwakmunsu/vote/repository/UserRepository.java
+++ b/src/main/java/com/kwakmunsu/vote/repository/UserRepository.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByNickname(String nickname);
+    boolean existsByUsername(String username);
+    boolean existsByNickname(String nickname);
 
     // user_id로 RT 찾기
     @Query("SELECT u.refreshToken FROM User u WHERE u.id = :userId")

--- a/src/main/java/com/kwakmunsu/vote/response/ResponseCode.java
+++ b/src/main/java/com/kwakmunsu/vote/response/ResponseCode.java
@@ -56,6 +56,8 @@ public enum ResponseCode  {
     // 기타 성공 응답
     READ_IS_LOGIN(StatusItem.OK, MessageItem.READ_IS_LOGIN),
     LOGIN_SUCCESS(StatusItem.OK, MessageItem.LOGIN_SUCCESS),
+    USERNAME_SUCCESS(StatusItem.OK, MessageItem.USERNAME_SUCCESS),
+    NICKNAME_SUCCESS(StatusItem.OK, MessageItem.NICKNAME_SUCCESS),
     LOGOUT_SUCCESS(StatusItem.OK, MessageItem.LOGOUT_SUCCESS),
     UPDATE_PASSWORD(StatusItem.NO_CONTENT, MessageItem.UPDATE_PASSWORD),
     PREVENT_GET_ERROR(StatusItem.NO_CONTENT, MessageItem.PREVENT_GET_ERROR),

--- a/src/main/java/com/kwakmunsu/vote/response/responseItem/MessageItem.java
+++ b/src/main/java/com/kwakmunsu/vote/response/responseItem/MessageItem.java
@@ -32,6 +32,8 @@ public class MessageItem {
         public static final String LOGIN_SUCCESS = "SUCCESS - 로그인 성공";
         public static final String LOGOUT_SUCCESS = "SUCCESS - 로그아웃 성공 및 user Refresh Token 삭제";
         public static final String UPDATE_PASSWORD = "SUCCESS - 비밀번호 수정 성공";
+        public static final String USERNAME_SUCCESS = "SUCCESS - 사용 가능한 아이디입니다.";
+        public static final String NICKNAME_SUCCESS = "SUCCESS - 사용 가능한 닉네임입니다.";
         public static final String READ_IS_LOGIN = "SUCCESS - 현재 로그인 여부 조회 성공";
         // < Auth - Error>
         public static final String UNAUTHORIZED = "ERROR - Unauthorized 에러";

--- a/src/main/java/com/kwakmunsu/vote/service/AuthService.java
+++ b/src/main/java/com/kwakmunsu/vote/service/AuthService.java
@@ -13,5 +13,8 @@ public interface AuthService {
     AuthDto.TokenResponse reissue(AuthDto.ReissueRequest reissueRequestDto, HttpServletRequest request);
     void logout(HttpServletRequest request,HttpServletResponse response);
 
+    boolean checkUsername(String username);
+    boolean checkNickname(String nickname);
+
 
 }

--- a/src/main/java/com/kwakmunsu/vote/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/kwakmunsu/vote/service/impl/AuthServiceImpl.java
@@ -54,17 +54,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     @Override
     public void signup(SignUpRequest signUpRequestDto) {
-        // 중복 체크
-        String username = signUpRequestDto.getUsername();
-        String nickname = signUpRequestDto.getNickname();
-        userRepository.findByUsername(username)
-                .ifPresent(user -> {
-                    throw new UserException.UserNameDuplicate(username);
-                });
-        userRepository.findByNickname(nickname)
-                .ifPresent(user -> {
-                    throw new UserException.NickNameDuplicate(nickname);
-                });
+
         String encodedPassword = bCryptPasswordEncoder.encode(signUpRequestDto.getPassword());
         User user = signUpRequestDto.toEntity(encodedPassword);
 
@@ -132,6 +122,17 @@ public class AuthServiceImpl implements AuthService {
         userRepository.deleteRefreshTokenById(userId); // DB  RT 삭제.
         Cookie resetCookie = createCookie("REFRESH", null,0);
         response.addCookie(resetCookie); // refreshToken을 쿠키에 담아서 응답에 추가
+    }
+
+    @Override
+    public boolean checkUsername(String username) {
+      return userRepository.existsByUsername(username);
+
+    }
+
+    @Override
+    public boolean checkNickname(String nickname) {
+       return userRepository.existsByNickname(nickname);
     }
 
 


### PR DESCRIPTION
# <i>PULL REQUEST</i>


## #️⃣연관된 이슈 

Feat/#17

## 📝작업 내용
- 기존 ->  /signup API 호출 시 ID, 닉네임 중복체크
- ID, 닉네임 중복체크 API 분리

### 스크린샷 (선택)
<img width="400" alt="스크린샷 2024-12-21 오후 5 15 53" src="https://github.com/user-attachments/assets/d379c86f-6fd5-44b3-9e82-6f8e072cb2d4" />
<img width="400" alt="스크린샷 2024-12-21 오후 5 15 38" src="https://github.com/user-attachments/assets/68a4fec5-118a-4ebc-acf9-60fe69b0429e" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
